### PR TITLE
Modernize sample and showcase all InspeKtor features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Kotlin compiler daemon logs
+.kotlin/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-Sample project to demonstrate features and usages of https://github.com/tabilzad/inspektor
+# InspeKtor Example
+
+A small Ktor server that demonstrates **every feature** of
+[InspeKtor](https://github.com/tabilzad/inspektor) — a Kotlin compiler plugin that generates an
+OpenAPI (Swagger) specification from your Ktor routes at build time, with no runtime overhead.
+
+## Run it
+
+```bash
+./gradlew run
+```
+
+Then open:
+
+- **Swagger UI** → http://localhost:8080/swagger
+- **OpenAPI plugin UI** → http://localhost:8080/openapi
+
+The spec itself is generated during compilation to `build/openapi/openapi.yaml` (run `./gradlew build`).
+
+## Versions
+
+| Tool      | Version       |
+|-----------|---------------|
+| Kotlin    | 2.4.0         |
+| Ktor      | 3.5.0         |
+| InspeKtor | 0.11.2-alpha  |
+| Gradle    | 8.14.4        |
+
+> InspeKtor is a Kotlin **compiler** plugin, so the project's Kotlin version must match the one the
+> plugin was built against (2.4.0 here).
+
+## What each part demonstrates
+
+Everything is enabled in `build.gradle.kts` under `swagger { … }` (servers, info, security schemes,
+`serialOverrides`, `inferResponseSchemas`, `useKDocsForDescriptions`, `polymorphicDiscriminator`).
+
+| Feature | Where |
+|---------|-------|
+| `@GenerateOpenApi` entry point + module wiring | [`Application.kt`](src/main/kotlin/com/example/Application.kt) |
+| Path / query / header params, request bodies, `@KtorDescription`, `@Tag` | [`routes/RegularRouting.kt`](src/main/kotlin/com/example/routes/RegularRouting.kt) |
+| **Automatic response inference** from `call.respond(...)` (no annotations) | [`routes/InferredResponseRouting.kt`](src/main/kotlin/com/example/routes/InferredResponseRouting.kt) |
+| Explicit responses: `responds<T>()`, `@KtorResponds`, `respondsNothing` (override inference) | [`routes/ExplicitResponseRouting.kt`](src/main/kotlin/com/example/routes/ExplicitResponseRouting.kt) |
+| Type-safe routing with Ktor `Resources` | [`routes/ResourceRouting.kt`](src/main/kotlin/com/example/routes/ResourceRouting.kt) + [`resources/Articles.kt`](src/main/kotlin/com/example/resources/Articles.kt) |
+| `@KtorSchema` / `@KtorField` field docs, `@SerialName`, KDoc descriptions | [`model/SampleRequest.kt`](src/main/kotlin/com/example/model/SampleRequest.kt), [`model/SampleResponse.kt`](src/main/kotlin/com/example/model/SampleResponse.kt) |
+| Sealed classes → `oneOf` + discriminator, value classes, generics, enums | [`model/AdvancedTypes.kt`](src/main/kotlin/com/example/model/AdvancedTypes.kt) |
+| Security schemes + global security requirements, `serialOverrides` | [`build.gradle.kts`](build.gradle.kts) |
+| Serving the spec + Swagger UI | [`routes/OpenApi.kt`](src/main/kotlin/com/example/routes/OpenApi.kt) |
+
+### Automatic response inference (highlight)
+
+With `inferResponseSchemas = true`, InspeKtor reads the response straight from the handler — status,
+content type and body schema — so the common case needs no annotations:
+
+```kotlin
+get("/inferred/sample") {
+    call.respond(SampleResponse())                    // -> 200, application/json, SampleResponse
+}
+post("/inferred/sample") {
+    call.respond(HttpStatusCode.Created, SampleResponse())  // -> 201
+}
+```
+
+It handles multiple branches, sealed (`oneOf`) types, value classes, generics, enums and `respondText`
+(`text/plain`). Explicit `responds<T>()` / `@KtorResponds` always win per status code; inference fills
+in the rest.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The spec itself is generated during compilation to `build/openapi/openapi.yaml` 
 
 | Tool      | Version       |
 |-----------|---------------|
+| JDK       | 11+           |
 | Kotlin    | 2.4.0         |
 | Ktor      | 3.5.0         |
 | InspeKtor | 0.11.2-alpha  |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import io.github.tabilzad.ktor.model.SecurityScheme
 
 plugins {
-    kotlin("jvm") version "2.1.10"
-    kotlin("plugin.serialization") version "2.1.10"
-    id("io.ktor.plugin") version "3.1.1"
-    id("io.github.tabilzad.inspektor") version "0.7.3-alpha"
+    kotlin("jvm") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.0"
+    id("io.ktor.plugin") version "3.5.0"
+    id("io.github.tabilzad.inspektor") version "0.11.2-alpha"
 }
 
 group = "com.example"
@@ -12,17 +12,43 @@ version = "0.0.1"
 
 swagger {
     documentation {
+        // Document the servers the API is reachable on.
         servers = listOf("http://localhost:8080", "http://127.0.0.1:8080")
+
         info {
             title = "Example Ktor Server"
-            description = "Example Server Description"
-            version = "10"
+            description = "A showcase of every InspeKtor feature"
+            version = "1.0.0"
 
             contact {
-                name = "Inspektor"
+                name = "InspeKtor"
                 url = "https://github.com/tabilzad/inspektor"
             }
+            license {
+                name = "Apache 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0"
+            }
         }
+
+        // Infer response schemas directly from `call.respond(...)` — no annotations required.
+        inferResponseSchemas = true
+
+        // Resolve schema/field descriptions from KDoc comments.
+        useKDocsForDescriptions = true
+
+        // Discriminator property name used for sealed-class `oneOf` schemas.
+        polymorphicDiscriminator = "type"
+
+        // Map an opaque/third-party type to a primitive OpenAPI type.
+        serialOverrides {
+            typeOverride("java.time.Instant") {
+                serializedAs = "string"
+                format = "date-time"
+                description = "ISO-8601 timestamp"
+            }
+        }
+
+        // Global security requirements + reusable security schemes.
         security {
             scopes {
                 or {
@@ -48,7 +74,6 @@ swagger {
                     name = "X-API-Key"
                 )
             }
-
         }
     }
 
@@ -64,14 +89,18 @@ application {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    // this is only to pull staged inspektor releases
-    maven("https://s01.oss.sonatype.org/content/repositories/staging")
 }
 
 dependencies {
     implementation(libs.bundles.ktor)
     implementation(libs.logging)
-    implementation("io.swagger.codegen.v3:swagger-codegen-generators:1.0.36")
+}
+
+// InspeKtor copies the generated spec into build/resources/main so it ships on the runtime classpath
+// (Swagger UI serves it from there). That copy task writes into the jar tasks' input dir, so declare
+// the dependency to satisfy Gradle's task-validation. (Tracked upstream — ideally the plugin wires
+// this so consumers don't have to.)
+tasks.withType<Jar>().configureEach {
+    dependsOn(tasks.withType<Copy>().matching { it.name.startsWith("copyOpenApiSpec") })
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import io.github.tabilzad.ktor.model.SecurityScheme
 
 plugins {
+    application
     kotlin("jvm") version "2.4.0"
     kotlin("plugin.serialization") version "2.4.0"
-    id("io.ktor.plugin") version "3.5.0"
     id("io.github.tabilzad.inspektor") version "0.11.2-alpha"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,17 @@
 [versions]
-kotlinVersion = "2.1.10"
-ktorVersion = "3.1.1"
+ktorVersion = "3.5.0"
+logback = "1.5.18"
 
 [bundles]
-ktor = ["ktor",
+ktor = [
+    "ktor",
     "ktorNetty",
     "ktorOpenApi",
     "ktorSwagger",
     "ktorResources",
     "ktorContentNegotiation",
-    "ktorSerialization"]
+    "ktorSerialization",
+]
 
 [libraries]
 ktor = { module = "io.ktor:ktor-server-core", version.ref = "ktorVersion" }
@@ -19,6 +21,4 @@ ktorSwagger = { module = "io.ktor:ktor-server-swagger", version.ref = "ktorVersi
 ktorResources = { module = "io.ktor:ktor-server-resources", version.ref = "ktorVersion" }
 ktorContentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktorVersion" }
 ktorSerialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
-logging = { module = "ch.qos.logback:logback-classic", version = "1.5.7" }
-
-
+logging = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,7 @@
-import java.net.URI
-
 pluginManagement {
     repositories {
-        // this is only to pull staged inspektor releases
-        maven("https://s01.oss.sonatype.org/content/repositories/staging")
-        mavenLocal()
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 

--- a/src/main/kotlin/com/example/Application.kt
+++ b/src/main/kotlin/com/example/Application.kt
@@ -1,34 +1,46 @@
 package com.example
 
+import com.example.routes.articleRoutes
 import com.example.routes.configureOpenApi
-import com.example.routes.configureRegularRoutes
-import com.example.routes.configureTypeSafeRoutes
+import com.example.routes.explicitResponseRoutes
+import com.example.routes.inferredResponseRoutes
+import com.example.routes.regularRoutes
 import io.github.tabilzad.ktor.annotations.GenerateOpenApi
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.resources.*
+import io.ktor.server.routing.*
 
 fun main() {
     embeddedServer(
         factory = Netty,
         port = 8080,
         host = "0.0.0.0",
-        module = Application::module
+        module = Application::module,
     ).start(wait = true)
 }
 
 fun Application.module() {
-    install(ContentNegotiation){
-        json()
-    }
+    install(ContentNegotiation) { json() }
+    install(Resources)
+
+    // Serves the generated spec + Swagger UI (see OpenApi.kt).
     configureOpenApi()
-    documentedModule()
+
+    // The single entry point InspeKtor analyzes. It walks every route reachable from here — including
+    // routes declared in the extension functions it calls — so feature demos live in separate files.
+    documentedApi()
 }
 
 @GenerateOpenApi
-fun Application.documentedModule() {
-    configureRegularRoutes()
-    configureTypeSafeRoutes()
+fun Application.documentedApi() {
+    routing {
+        regularRoutes()
+        inferredResponseRoutes()
+        explicitResponseRoutes()
+        articleRoutes()
+    }
 }

--- a/src/main/kotlin/com/example/model/AdvancedTypes.kt
+++ b/src/main/kotlin/com/example/model/AdvancedTypes.kt
@@ -1,0 +1,44 @@
+package com.example.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+// Value classes are unwrapped to their underlying type, so this is documented simply as a `string`.
+/** A type-safe user identifier. */
+@JvmInline
+@Serializable
+value class UserId(val value: String)
+
+// Sealed types become an OpenAPI `oneOf` with a discriminator; each concrete variant carries the
+// discriminator (`type`) as a required, pinned property (matching what kotlinx.serialization writes
+// on the wire). The discriminator name comes from @JsonClassDiscriminator / `polymorphicDiscriminator`.
+/** A payment method. */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("type")
+sealed interface PaymentMethod {
+
+    @Serializable
+    @SerialName("card")
+    data class Card(val last4: String, val brand: String) : PaymentMethod
+
+    @Serializable
+    @SerialName("paypal")
+    data class PayPal(val email: String) : PaymentMethod
+
+    @Serializable
+    @SerialName("cash")
+    data object Cash : PaymentMethod
+}
+
+// Parameterized types are fully supported; the schema is named per instantiation (e.g. Page_Of_X).
+/** A generic pagination envelope. */
+@Serializable
+data class Page<T>(
+    val items: List<T>,
+    val total: Int,
+    val page: Int,
+    val pageSize: Int,
+)

--- a/src/main/kotlin/com/example/model/SampleRequest.kt
+++ b/src/main/kotlin/com/example/model/SampleRequest.kt
@@ -1,26 +1,35 @@
 package com.example.model
 
-import io.github.tabilzad.ktor.annotations.KtorFieldDescription
+import io.github.tabilzad.ktor.annotations.KtorField
+import io.github.tabilzad.ktor.annotations.KtorSchema
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
+import java.time.Instant
 
+// Shows field-level docs via @KtorField and a class description via @KtorSchema (these replace the
+// deprecated @KtorFieldDescription), plus nested refs, collections, maps, and a type mapped to a
+// primitive via `serialOverrides` (see build.gradle.kts).
 @Serializable
-@KtorFieldDescription("This is a request sample")
+@KtorSchema(description = "Payload for creating a sample")
 data class SampleRequest(
-    @KtorFieldDescription("Integer")
+    @KtorField("An integer value")
     val int: Int,
     val string: String,
     val double: Double,
-    @KtorFieldDescription("Reference to another object")
+    @KtorField("Reference to another object")
     val objectRef: ObjectRef,
-    @KtorFieldDescription("Collection")
+    @KtorField("A collection of strings")
     val list: List<String>,
     val setObjectRefs: Set<ObjectRef>,
-    val map: Map<String, ObjectRef>
+    val map: Map<String, ObjectRef>,
+    @Contextual
+    @KtorField(description = "Created timestamp", format = "date-time")
+    val instant: Instant,
 )
 
 @Serializable
 data class ObjectRef(
-    @KtorFieldDescription("Integer")
+    @KtorField("An integer value")
     val int: Int = 0,
-    val list: List<String> = emptyList()
+    val list: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/example/model/SampleResponse.kt
+++ b/src/main/kotlin/com/example/model/SampleResponse.kt
@@ -3,16 +3,22 @@ package com.example.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// Descriptions on this type come from KDoc (`useKDocsForDescriptions = true`) rather than annotations.
+/** Standard response payload. */
 @Serializable
 data class SampleResponse(
+    /** An integer value. */
     val int: Int = 0,
     val string: String = "",
     val double: Double = 0.0,
     val objectRef: ObjectRef = ObjectRef(),
     val list: List<String> = emptyList(),
+    /** Serialized under a custom JSON name via @SerialName. */
     @SerialName("objects")
     val setObjectRefs: Set<ObjectRef> = emptySet(),
-    val map: Map<String, ObjectRef> = mapOf()
+    val map: Map<String, ObjectRef> = mapOf(),
+    /** Current lifecycle status. */
+    val status: OrderStatus = OrderStatus.PENDING,
 ) {
     companion object {
         fun fromRequest(request: SampleRequest): SampleResponse = SampleResponse(
@@ -22,11 +28,20 @@ data class SampleResponse(
             objectRef = request.objectRef,
             list = request.list,
             setObjectRefs = request.setObjectRefs,
-            map = request.map
+            map = request.map,
         )
     }
 }
 
+/** A consistent error envelope returned by failing endpoints. */
+@Serializable
 data class SampleErrorResponse(
-    val errorCode: Int, val errorMessage: String
+    /** Machine-readable error code. */
+    val errorCode: Int,
+    /** Human-readable error message. */
+    val errorMessage: String,
 )
+
+/** Lifecycle status of an order — enums are rendered as a string schema with an `enum` list. */
+@Serializable
+enum class OrderStatus { PENDING, SHIPPED, DELIVERED, CANCELLED }

--- a/src/main/kotlin/com/example/resources/Articles.kt
+++ b/src/main/kotlin/com/example/resources/Articles.kt
@@ -1,12 +1,12 @@
 package com.example.resources
 
-import io.github.tabilzad.ktor.annotations.KtorFieldDescription
+import io.github.tabilzad.ktor.annotations.KtorField
 import io.ktor.resources.*
 
 @Resource("/articles")
 class Articles(
-    @KtorFieldDescription("Articles sort order")
-    val sort: String? = "new"
+    @KtorField("Articles sort order")
+    val sort: String? = "new",
 ) {
     @Resource("new")
     class New(val parent: Articles = Articles())
@@ -14,8 +14,8 @@ class Articles(
     @Resource("{id}")
     class Id(
         val parent: Articles = Articles(),
-        @KtorFieldDescription("Article identifier")
-        val id: Long
+        @KtorField("Article identifier")
+        val id: Long,
     ) {
         @Resource("edit")
         class Edit(val parent: Id)

--- a/src/main/kotlin/com/example/routes/ExplicitResponseRouting.kt
+++ b/src/main/kotlin/com/example/routes/ExplicitResponseRouting.kt
@@ -1,0 +1,62 @@
+package com.example.routes
+
+import com.example.model.SampleErrorResponse
+import com.example.model.SampleResponse
+import io.github.tabilzad.ktor.annotations.KtorDescription
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.github.tabilzad.ktor.annotations.Tag
+import io.github.tabilzad.ktor.annotations.responds
+import io.github.tabilzad.ktor.annotations.respondsNothing
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+/**
+ * Explicit response documentation. Use these when you want to document responses that aren't obvious
+ * from the handler (extra status codes, error envelopes, collections). Explicit declarations always
+ * take precedence over inference for the same status code; inference still fills in the rest.
+ */
+@Tag(["Explicit Responses"])
+fun Route.explicitResponseRoutes() = route("/customers") {
+
+    // @KtorResponds: declare every status code up front, with descriptions.
+    @KtorDescription(
+        summary = "Get a customer by id",
+        description = "Returns the customer, or an error envelope when not found.",
+    )
+    @KtorResponds(
+        mapping = [
+            ResponseEntry("200", SampleResponse::class, description = "Customer found"),
+            ResponseEntry("404", SampleErrorResponse::class, description = "Customer not found"),
+        ],
+    )
+    get("/{id}") {
+        call.respond(SampleResponse())
+    }
+
+    // @KtorResponds with isCollection = true documents an array response.
+    @KtorResponds(
+        mapping = [ResponseEntry("200", SampleResponse::class, isCollection = true)],
+    )
+    get {
+        call.respond(listOf(SampleResponse()))
+    }
+
+    // responds<T>() DSL: inline, type-safe per-status declarations.
+    @KtorDescription(summary = "Create a customer")
+    post {
+        responds<SampleResponse>(HttpStatusCode.Created, description = "Created")
+        responds<SampleErrorResponse>(HttpStatusCode.Conflict, description = "Already exists")
+        call.respond(HttpStatusCode.Created, SampleResponse())
+    }
+
+    // respondsNothing: a body-less response (e.g. 204 No Content).
+    @KtorDescription(summary = "Delete a customer")
+    delete("/{id}") {
+        respondsNothing(HttpStatusCode.NoContent, description = "Deleted")
+        responds<SampleErrorResponse>(HttpStatusCode.NotFound, description = "Customer not found")
+        call.respond(HttpStatusCode.NoContent)
+    }
+}

--- a/src/main/kotlin/com/example/routes/InferredResponseRouting.kt
+++ b/src/main/kotlin/com/example/routes/InferredResponseRouting.kt
@@ -1,0 +1,77 @@
+package com.example.routes
+
+import com.example.model.OrderStatus
+import com.example.model.Page
+import com.example.model.PaymentMethod
+import com.example.model.SampleErrorResponse
+import com.example.model.SampleResponse
+import com.example.model.UserId
+import io.github.tabilzad.ktor.annotations.KtorDescription
+import io.github.tabilzad.ktor.annotations.Tag
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+/**
+ * Automatic response inference (`inferResponseSchemas = true`). None of these endpoints declare their
+ * responses with `responds<T>()` or `@KtorResponds` — the status code, content type and body schema are
+ * inferred directly from the `call.respond(...)` calls in the handler.
+ */
+@Tag(["Inferred Responses"])
+fun Route.inferredResponseRoutes() = route("/inferred") {
+
+    // Plain respond -> 200 + SampleResponse schema.
+    @KtorDescription(summary = "Inferred 200")
+    get("/sample") {
+        call.respond(SampleResponse())
+    }
+
+    // The status is read from the HttpStatusCode argument -> 201.
+    @KtorDescription(summary = "Inferred 201 from HttpStatusCode argument")
+    post("/sample") {
+        call.respond(HttpStatusCode.Created, SampleResponse())
+    }
+
+    // Multiple respond sites across branches -> multiple inferred responses (200 + 400).
+    @KtorDescription(summary = "Inferred from both branches")
+    get("/customers/{id}") {
+        val id = call.parameters["id"]
+        if (id.isNullOrBlank()) {
+            call.respond(HttpStatusCode.BadRequest, SampleErrorResponse(400, "missing id"))
+        } else {
+            call.respond(SampleResponse())
+        }
+    }
+
+    // Sealed type -> `oneOf` with a discriminator; each variant carries the pinned `type` property.
+    @KtorDescription(summary = "Sealed (oneOf) response")
+    get("/payment") {
+        val payment: PaymentMethod = PaymentMethod.Card(last4 = "4242", brand = "VISA")
+        call.respond(payment)
+    }
+
+    // Generic envelope -> Page<SampleResponse>.
+    @KtorDescription(summary = "Generic paginated response")
+    get("/page") {
+        call.respond(Page(items = listOf(SampleResponse()), total = 1, page = 1, pageSize = 20))
+    }
+
+    // Value class -> unwrapped to its underlying `string` type.
+    @KtorDescription(summary = "Value-class response")
+    get("/user-id") {
+        call.respond(UserId("u-123"))
+    }
+
+    // Enum -> string schema with an `enum` list.
+    @KtorDescription(summary = "Enum response")
+    get("/status") {
+        call.respond(OrderStatus.SHIPPED)
+    }
+
+    // respondText -> text/plain content type with a string schema.
+    @KtorDescription(summary = "Plain text response")
+    get("/text") {
+        call.respondText("pong")
+    }
+}

--- a/src/main/kotlin/com/example/routes/RegularRouting.kt
+++ b/src/main/kotlin/com/example/routes/RegularRouting.kt
@@ -1,11 +1,8 @@
 package com.example.routes
 
-import com.example.model.SampleErrorResponse
 import com.example.model.SampleRequest
 import com.example.model.SampleResponse
 import io.github.tabilzad.ktor.annotations.KtorDescription
-import io.github.tabilzad.ktor.annotations.KtorResponds
-import io.github.tabilzad.ktor.annotations.ResponseEntry
 import io.github.tabilzad.ktor.annotations.Tag
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -13,67 +10,28 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
-@Tag(["All Endpoints"])
-fun Application.configureRegularRoutes() {
-    routing {
-        customerRoutes()
-        orderRoutes()
+/**
+ * The basics: path / query / header parameters, request bodies, endpoint descriptions, tags, and
+ * hiding an endpoint. Tags (declared with [Tag]) group endpoints in the generated spec / Swagger UI.
+ */
+@Tag(["Basics"])
+fun Route.regularRoutes() {
 
-        @Tag(["Shipments"])
-        route("/shipments") {
-            get {
-                call.respond(SampleResponse())
-            }
-            post<SampleRequest> { request ->
-                call.respond(SampleResponse.fromRequest(request))
-            }
-        }
-    }
-}
-
-@Tag(["Customer"])
-fun Route.customerRoutes() {
-    @KtorResponds(
-        mapping = [
-            ResponseEntry("200", SampleResponse::class),
-            ResponseEntry("400", SampleErrorResponse::class)
-        ]
-    )
     @KtorDescription(
-        summary = "Get customer by id",
-        description = "Returns customer by id"
+        summary = "Get an item",
+        description = "Path, query and header parameters are detected automatically from the handler.",
     )
-    get("/customer/{id}") {
-        val idParam = call.parameters["id"]
-        call.respond(HttpStatusCode.OK, SampleResponse()).also {
-            println(idParam)
-        }
+    get("/items/{id}") {
+        val id = call.parameters["id"]                  // path parameter `{id}`
+        val sort = call.request.queryParameters["sort"] // query parameter `?sort=`
+        val apiKey = call.request.headers["X-API-Key"]  // header parameter
+        call.respond(SampleResponse(string = "item $id sorted by $sort for $apiKey"))
     }
 
-    @KtorResponds(mapping = [ResponseEntry("200", SampleResponse::class)])
-    post("/customer") {
-        val body = call.receive<SampleRequest>()
-        call.respond(HttpStatusCode.OK, SampleResponse.fromRequest(body))
-    }
-}
-
-@Tag(["Order"])
-fun Route.orderRoutes() {
-    route("/orders") {
-        @KtorResponds(mapping = [ResponseEntry("200", SampleResponse::class, isCollection = true)])
-        get("/all") {
-            val query = call.request.queryParameters["sort"]
-            call.respond(HttpStatusCode.OK, SampleResponse()).also {
-                println(query)
-            }
-        }
-
-        @KtorResponds(mapping = [ResponseEntry("200", SampleResponse::class)])
-        get("/{id}") {
-            val idParam = call.parameters["id"]
-            call.respond(HttpStatusCode.OK, SampleResponse()).also {
-                println(idParam)
-            }
-        }
+    @KtorDescription(summary = "Create an item")
+    post("/items") {
+        // The request body schema is inferred from `call.receive<T>()`.
+        val request = call.receive<SampleRequest>()
+        call.respond(HttpStatusCode.Created, SampleResponse.fromRequest(request))
     }
 }

--- a/src/main/kotlin/com/example/routes/ResourceRouting.kt
+++ b/src/main/kotlin/com/example/routes/ResourceRouting.kt
@@ -1,51 +1,51 @@
 package com.example.routes
 
-import com.example.model.SampleResponse
 import com.example.resources.Articles
-import io.github.tabilzad.ktor.annotations.KtorResponds
-import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.github.tabilzad.ktor.annotations.KtorDescription
+import io.github.tabilzad.ktor.annotations.Tag
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.resources.delete
 import io.ktor.server.resources.get
 import io.ktor.server.resources.post
-import io.ktor.server.resources.delete
 import io.ktor.server.resources.put
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.server.resources.Resources
 
-fun Application.configureTypeSafeRoutes() {
-    install(Resources)
-    routing {
-        @KtorResponds(mapping = [ResponseEntry("200", SampleResponse::class)])
-        get<Articles> { article ->
-            // Get all articles ...
-            call.respondText("List of articles sorted starting from ${article.sort}")
-        }
-        @KtorResponds(mapping = [ResponseEntry("200", SampleResponse::class)])
-        get<Articles.New> {
-            // Show a page with fields for creating a new article ...
-            call.respondText("Create a new article")
-        }
-        post<Articles> {
-            // Save an article ...
-            call.respondText("An article is saved", status = HttpStatusCode.Created)
-        }
-        get<Articles.Id> { article ->
-            // Show an article with id ${article.id} ...
-            call.respondText("An article with id ${article.id}", status = HttpStatusCode.OK)
-        }
-        get<Articles.Id.Edit> { article ->
-            // Show a page with fields for editing an article ...
-            call.respondText("Edit an article with id ${article.parent.id}", status = HttpStatusCode.OK)
-        }
-        put<Articles.Id> { article ->
-            // Update an article ...
-            call.respondText("An article with id ${article.id} updated", status = HttpStatusCode.OK)
-        }
-        delete<Articles.Id> { article ->
-            // Delete an article ...
-            call.respondText("An article with id ${article.id} deleted", status = HttpStatusCode.OK)
-        }
+/**
+ * Type-safe routing with Ktor [Resources]. Paths and parameters are derived from the `@Resource`
+ * classes (see resources/Articles.kt); responses are inferred from the handlers. `Resources` is
+ * installed in Application.module().
+ */
+@Tag(["Articles (type-safe)"])
+fun Route.articleRoutes() {
+
+    @KtorDescription(summary = "List articles", description = "Supports a `sort` query parameter.")
+    get<Articles> { article ->
+        call.respondText("List of articles sorted starting from ${article.sort}")
+    }
+
+    get<Articles.New> {
+        call.respondText("Create a new article")
+    }
+
+    post<Articles> {
+        call.respondText("An article is saved", status = HttpStatusCode.Created)
+    }
+
+    get<Articles.Id> { article ->
+        call.respondText("An article with id ${article.id}")
+    }
+
+    get<Articles.Id.Edit> { article ->
+        call.respondText("Edit an article with id ${article.parent.id}")
+    }
+
+    put<Articles.Id> { article ->
+        call.respondText("An article with id ${article.id} updated")
+    }
+
+    delete<Articles.Id> { article ->
+        call.respondText("An article with id ${article.id} deleted")
     }
 }


### PR DESCRIPTION
The sample was a few releases behind (Ktor 3.1.2, Kotlin 2.1.21, a `*-local` plugin build) and
didn't demonstrate any of the newer InspeKtor features. This updates it to the latest releases and
turns it into a complete, navigable showcase that builds on **JDK 11+**.

## Toolchain
- Kotlin `2.1.21 → 2.4.0`, Ktor `3.1.2 → 3.5.0`, Gradle `8.4 → 8.14.4`
- InspeKtor `0.8.7-alpha-local-1 → 0.11.2-alpha`, resolved from **Maven Central**
- Removed the `mavenLocal()` / sonatype-staging repository hacks and the unused
  `swagger-codegen-generators` dependency (`ktor-server-openapi` brings it transitively)
- **Dropped `io.ktor.plugin`** and apply the core `application` plugin instead: the Ktor Gradle
  plugin 3.5.0 requires a JDK 17 runtime for the build itself, but this sample doesn't use any of
  its features (it uses `embeddedServer` + explicit Ktor deps). InspeKtor and the Ktor libraries
  target JVM 11, so the build now runs on **JDK 11+**.

## Features demonstrated
Routes are now grouped by theme, one file each, so the project reads top-to-bottom:

| Area | File |
|------|------|
| **Automatic response inference** from `call.respond(...)` (the new headline) | `routes/InferredResponseRouting.kt` |
| Explicit `responds<T>()` / `@KtorResponds` / `respondsNothing` (override inference) | `routes/ExplicitResponseRouting.kt` |
| Path/query/header params, request bodies, `@KtorDescription`, `@Tag` | `routes/RegularRouting.kt` |
| Type-safe `Resources` | `routes/ResourceRouting.kt` + `resources/Articles.kt` |
| Sealed → `oneOf` + discriminator (pinned variant property), value classes, generics, enums | `model/AdvancedTypes.kt` |
| `@KtorSchema` / `@KtorField` (replacing deprecated `@KtorFieldDescription`) + KDoc descriptions | `model/*` |
| Security schemes + `serialOverrides` | `build.gradle.kts` |

The inference showcase alone covers `200`/`201`, multi-branch (`200` + `400`), sealed `oneOf`,
value-class→`string`, generic `Page<T>`, enum, and `respondText`→`text/plain` — all with **no**
response annotations.

## Housekeeping
- Removed stale `old_openapi.yaml`; ignore `.kotlin/` daemon logs
- Rewrote the README with a feature map, run instructions, and a version table

## Verification
`./gradlew build` succeeds and running the app serves **Swagger UI at `/swagger`** and the
**OpenAPI document at `/openapi`** (both `200`). The generated spec renders every feature above,
including the sealed `oneOf` with each variant carrying its pinned `type` discriminator.

## One thing to flag upstream
With Gradle 8.14.4, `./gradlew build` initially failed because InspeKtor's `copyOpenApiSpec*` task
writes the spec into `build/resources/main` (so it ships on the runtime classpath) without the `jar`
task declaring a dependency on it — Gradle's task-validation rejects the implicit dependency. Small
workaround in `build.gradle.kts`:

```kotlin
tasks.withType<Jar>().configureEach {
    dependsOn(tasks.withType<Copy>().matching { it.name.startsWith("copyOpenApiSpec") })
}
```

This isn't something a consumer should have to wire by hand — the plugin's `saveInBuild` copy ideally
declares the dependency itself. Worth a follow-up in the inspektor repo.
